### PR TITLE
Fixed wrong dash in the npm command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ python -m SimpleHTTPServer
 or
 
 ```
-npm -i g http-server
+npm i -g http-server
 http-server .
 ```
 


### PR DESCRIPTION
The command line for installing the http-server was wrong, i.e.,
the dash was before the command i instead of the command line
option g.